### PR TITLE
run ci on ROS noetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ services:
 
 env:
   matrix:
-    - ROS_DISTRO="kinetic"
-    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="noetic"
 
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master


### PR DESCRIPTION
Thanks @Crowdedlight for updating the code to work with Python3! used it with success and it saved me some time.

This commit is from https://github.com/clearpathrobotics/robot_upstart/pull/98 to see if the port would pass CI on the upstream repo